### PR TITLE
Depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Creating and managing website and port probes
 
 Creating Annotations in the CopperEgg UI for chef run events.
 =====
-The CopperEgg Cookbook includes integration with the Chef Report and Exception Handlers. To enable this functionality:
-1. include the chef_handler cookbook from Opscode in your chef repo, and in your run list, or have your application cookbook `depend` on the copperegg cookbook in its metadata.
-1. include the recipe copperegg-handler.rb in your run_list or include it in your application cookbook with `include_recipe`.
+The CopperEgg Cookbook includes integration with the Chef Report and Exception
+Handlers. To enable this functionality choose one of the following:
+* Include the recipe copperegg-handler.rb in your run_list, or
+* Include the recipe copperegg-handler in your application cookbook with
+`include_recipe`.
 
 That's it!
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,8 @@ description      "Installs/Configures CopperEgg services"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.1"
 
+depends 'chef_handler', '> 1.0.0'
+
 recipe "copperegg::default", "Installs CopperEgg collector binary"
 
 # Uncomment to include support for Windows


### PR DESCRIPTION
```
Add chef_handler dependency, simply README.
CopperEgg/chef-copperegg#5

Add dependency on chef_handler to metadata and simplified directions
for using annotation.
```
