### PR TITLE
Fixed Idempotence

### DIFF
--- a/libraries/copperegg_lib.rb
+++ b/libraries/copperegg_lib.rb
@@ -59,7 +59,7 @@ module CopperEgg
         collver.chomp!
       end
       `curl -sk https://#{@apikey}:U@api.copperegg.com/chef.sh  > /tmp/chef.sh`
-      installer_ver = `grep URL_LINUX_64 /tmp/chef.sh -m 1 | cut -d '/' -f6`
+      installer_ver = `grep URL_LINUX_64 /tmp/chef.sh -m 1 | cut -d '/' -f5`
       installer_ver.chomp!
       if (updated == true) 
         if (rundir == true)


### PR DESCRIPTION
The CopperEgg cookbook was reinstalling the agent each time chef ran. 
This was causing gaps in data while the service was being restarted. 

This fixes where to `cut` the URL to find the correct version of the `installer_ver` :+1: 
