### PR TITLE
Fix for failed download

### DIFF
--- a/libraries/copperegg_lib.rb
+++ b/libraries/copperegg_lib.rb
@@ -62,7 +62,7 @@ module CopperEgg
       installer_ver = `grep URL_LINUX_64 /tmp/chef.sh -m 1 | cut -d '/' -f5`
       installer_ver.chomp!
       if (installer_ver.empty?)
-        Chef::Log.warn "Could not get installer verision from the API...skpping check"
+        Chef::Log.warn "Could not get installer version from the API...skipping check"
         rslt = false 
       elsif (updated == true) 
         if (rundir == true)


### PR DESCRIPTION
Hello again!

If for any reason the CopperEgg install script fails to download, the recipe will actually **uninstall** the CopperEgg agent.

The `installed_ver` variable is empty and won't match the `collver` variable and thinks it's an update and will go though the uninstall process and try to run a failed download `chef.sh` script. 

This fix will check to ensure that `install_ver` actually contains data before doing anything. 
