### PR TITLE
Add support for specifying probe headers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ Chef Cookbook for CopperEgg services
 
 Recent Updates
 ============
+Version 0.2.6    Released ???
+Added support for specifying probe headers.
+
 Version 0.2.5    Released March 10, 2014
-Simplified exception handling, and increased retries for HTTP Get. 
+Simplified exception handling, and increased retries for HTTP Get.
 
 Version 0.2.4    Released February 2, 2014
 Added better retry handling on http Get

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "support@copperegg.com"
 license          "MIT"
 description      "Installs/Configures CopperEgg services"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.5"
+version          "0.2.6"
 
 depends 'chef_handler', '> 1.0.0'
 

--- a/providers/probe.rb
+++ b/providers/probe.rb
@@ -39,7 +39,8 @@ action :update do
                   'tags' => @new_resource.tags,
                   'probe_data' => @new_resource.probe_data,
                   'checkcontents' => @new_resource.checkcontents,
-                  'contentmatch' => @new_resource.contentmatch   } 
+                  'contentmatch' => @new_resource.contentmatch,
+                  'headers' => @new_resource.headers }
         @cuegg.update_probe(@current_resource.probe_id, params)
       rescue => error
         Chef::Log.warn(error.to_s)
@@ -59,7 +60,8 @@ action :update do
                   'tags' => @new_resource.tags,
                   'probe_data' => @new_resource.probe_data,
                   'checkcontents' => @new_resource.checkcontents,
-                  'contentmatch' => @new_resource.contentmatch   } 
+                  'contentmatch' => @new_resource.contentmatch,
+                  'headers' => @new_resource.headers }
         probehash = @cuegg.create_probe(@new_resource.probe_desc, params )
         Chef::Log.info "probehash returned #{probehash.inspect}"
         if probehash != nil

--- a/resources/probe.rb
+++ b/resources/probe.rb
@@ -31,6 +31,7 @@ attribute :tags, :kind_of => [NilClass,Array]
 attribute :probe_data, :kind_of => [NilClass,String]
 attribute :checkcontents, :kind_of => [NilClass,String]
 attribute :contentmatch, :kind_of => [NilClass,String]
+attribute :headers, :kind_of => [NilClass,Hash]
 
 attr_accessor :exists   # set when the resource has already been created
 


### PR DESCRIPTION
Added support for probe headers, eg:

  headers = {
    'User-Agent' => 'copperegg'
  }

  copperegg_probe "#{tenant.name}-restapi" do
      provider 'copperegg_probe'
      action :update
      tags [env_tag, tenant.name]
      headers headers
      probe_desc description
      probe_dest uri
      type 'GET'
  end
