### PR TITLE
Specify a UTF-8 encoding when reading the README

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "CopperEgg, Inc."
 maintainer_email "support@copperegg.com"
 license          "MIT"
 description      "Installs/Configures CopperEgg services"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'), encoding: 'utf-8')
 version          "0.2.5"
 
 depends 'chef_handler', '> 1.0.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "CopperEgg, Inc."
 maintainer_email "support@copperegg.com"
 license          "MIT"
 description      "Installs/Configures CopperEgg services"
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'), encoding: 'utf-8')
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'), { :encoding => 'utf-8' })
 version          "0.2.5"
 
 depends 'chef_handler', '> 1.0.0'


### PR DESCRIPTION
The README.md file is dynamically read in as the long_description in the metadata. The README includes a UTF-8 character (©) which fails in newer versions of ruby which is more strict about character encodings.

This, for example, suddenly caused our copperegg recipe to begin to fail in AWS OpsWorks after we upgraded some our system. The error message (in case someone else finds it here via google) is below.

The solution is to force the encoding when reading in the README, to ensure it uses UTF-8.

```
[2014-08-21T17:32:45+00:00] INFO: Forking chef instance to converge...
[2014-08-21T17:32:45+00:00] INFO: *** Chef 11.10.4 ***
[2014-08-21T17:32:45+00:00] INFO: Chef-client pid: 27641
[2014-08-21T17:32:46+00:00] INFO: Setting the run_list to ["opsworks_custom_cookbooks::load", "opsworks_custom_cookbooks::execute"] from JSON
[2014-08-21T17:32:46+00:00] WARN: Run List override has been provided.
[2014-08-21T17:32:46+00:00] WARN: Original Run List: [recipe[opsworks_custom_cookbooks::load], recipe[opsworks_custom_cookbooks::execute]]
[2014-08-21T17:32:46+00:00] WARN: Overridden Run List: [recipe[opsworks_ganglia::configure-client], recipe[ssh_users], recipe[mysql::client], recipe[agent_version], recipe[opsworks_stack_state_sync], recipe[rails::configure], recipe[copperegg], recipe[newrelic], recipe[sumologic-collector], recipe[test_suite], recipe[opsworks_cleanup]]
[2014-08-21T17:32:46+00:00] INFO: Run List is [recipe[opsworks_ganglia::configure-client], recipe[ssh_users], recipe[mysql::client], recipe[agent_version], recipe[opsworks_stack_state_sync], recipe[rails::configure], recipe[copperegg], recipe[newrelic], recipe[sumologic-collector], recipe[test_suite], recipe[opsworks_cleanup]]
[2014-08-21T17:32:46+00:00] INFO: Run List expands to [opsworks_ganglia::configure-client, ssh_users, mysql::client, agent_version, opsworks_stack_state_sync, rails::configure, copperegg, newrelic, sumologic-collector, test_suite, opsworks_cleanup]
[2014-08-21T17:32:46+00:00] INFO: Starting Chef Run for prod-app1.localdomain
[2014-08-21T17:32:46+00:00] INFO: Running start handlers
[2014-08-21T17:32:46+00:00] INFO: Start handlers complete.
[2014-08-21T17:32:46+00:00] INFO: HTTP Request Returned 404 Not Found: Object not found: /reports/nodes/prod-app1.localdomain/runs
[2014-08-21T17:32:48+00:00] ERROR: #<Encoding::InvalidByteSequenceError: "\xC2" on US-ASCII>
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/cookbook/metadata.rb:444:in `encode'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/cookbook/metadata.rb:444:in `to_json'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/cookbook/metadata.rb:444:in `to_json'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/json-1.7.7/lib/json/common.rb:285:in `generate'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/json-1.7.7/lib/json/common.rb:285:in `pretty_generate'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/chef_fs/chef_fs_data_store.rb:102:in `block in get'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/chef_fs/chef_fs_data_store.rb:339:in `with_entry'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-11.10.4/lib/chef/chef_fs/chef_fs_data_store.rb:82:in `get'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-zero-1.7.3/lib/chef_zero/rest_base.rb:42:in `get_data'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-zero-1.7.3/lib/chef_zero/endpoints/environment_cookbook_versions_endpoint.rb:77:in `block in depsolve'
[snip]
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-zero-1.7.3/lib/chef_zero/endpoints/environment_cookbook_versions_endpoint.rb:37:in `post'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-zero-1.7.3/lib/chef_zero/rest_base.rb:29:in `call'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-zero-1.7.3/lib/chef_zero/rest_router.rb:23:in `call'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/chef-zero-1.7.3/lib/chef_zero/server.rb:335:in `block in make_app'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/server.rb:412:in `call'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/server.rb:412:in `handle_request'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/server.rb:306:in `process_client'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/server.rb:215:in `block in run'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/thread_pool.rb:94:in `call'
/opt/aws/opsworks/releases/20140815100543_323/vendor/bundle/ruby/2.0.0/gems/puma-1.6.3/lib/puma/thread_pool.rb:94:in `block in spawn_thread'
[2014-08-21T17:32:48+00:00] INFO: HTTP Request Returned 500 Internal Server Error: 
```
