### PR TITLE
CE-908: redundant return statements removed

### DIFF
--- a/libraries/copperegg_lib.rb
+++ b/libraries/copperegg_lib.rb
@@ -89,7 +89,7 @@ module CopperEgg
 
     # returns an array of probe_hashes, or nil
     def get_probelist()
-      Chef::Log.info "get_probelist" 
+      Chef::Log.info "get_probelist"
       return api_request('get', 'probes.json')
     end
 
@@ -226,8 +226,7 @@ module CopperEgg
             end
             response_body = valid_json?(response.body)
             if response_body == nil
-              raise "CopperEgg::API invalid JSON response ... #{request}  #{request_uri}" 
-              return nil
+              raise "CopperEgg::API invalid JSON response ... #{request}  #{request_uri}"
             else
               return response_body
             end
@@ -236,8 +235,7 @@ module CopperEgg
           exception_try_count += 1
           if exception_try_count > attempts
             #log "#{e.inspect}"
-            raise "CopperEgg::API #{e} ... #{exception_try_count} retries: #{request}  #{request_uri}" 
-            return nil
+            raise "CopperEgg::API #{e} ... #{exception_try_count} retries: #{request}  #{request_uri}"
           else
             if $verbose == true
               puts "\nGet: exception: retrying\n"
@@ -253,8 +251,7 @@ module CopperEgg
         sleep 1.0
       end
 #     need to fail here
-      raise "CopperEgg::API ... exceeded #{connect_try_count} retries: #{request}  #{request_uri}" 
-      return nil
+      raise "CopperEgg::API ... exceeded #{connect_try_count} retries: #{request}  #{request_uri}"
     end
   end
 end


### PR DESCRIPTION
Just removed unneeded return statements after exceptions.
